### PR TITLE
Update redump url to new official website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # 🎮 Fresh1G1R
 
-Fresh1G1R generates fresh daily, up-to-date 1G1R (One Game One ROM) DAT files for [Redump](http://redump.org) and [No-Intro](https://www.no-intro.org) collections, processed with several different [Retool](https://github.com/unexpectedpanda/retool) filter configurations, currently: **[Hearto](#-hearto)**, **[PropeR](#-proper)**, and **[McLean](#-mclean)**.
+Fresh1G1R generates fresh daily, up-to-date 1G1R (One Game One ROM) DAT files for [Redump](https://redump.info) and [No-Intro](https://www.no-intro.org) collections, processed with several different [Retool](https://github.com/unexpectedpanda/retool) filter configurations, currently: **[Hearto](#-hearto)**, **[PropeR](#-proper)**, and **[McLean](#-mclean)**.
 
 ## ❓ What Is This?
 
-This repository provides the latest, box-fresh 1G1R DAT files for every system in both [Redump](http://redump.org) and [No-Intro](https://www.no-intro.org) collections, processed through the latest [Retool](https://github.com/unexpectedpanda/retool) release with curated 1G1R filter configurations. The DAT files are automatically updated daily via GitHub Actions, ensuring the 1G1R DATs available are always the most current filtered collections.
+This repository provides the latest, box-fresh 1G1R DAT files for every system in both [Redump](https://redump.info) and [No-Intro](https://www.no-intro.org) collections, processed through the latest [Retool](https://github.com/unexpectedpanda/retool) release with curated 1G1R filter configurations. The DAT files are automatically updated daily via GitHub Actions, ensuring the 1G1R DATs available are always the most current filtered collections.
 
 ## 📚 Available Collections
 
@@ -30,7 +30,7 @@ Based on the [Hearto 1G1R Collection](https://www.reddit.com/r/Roms/comments/1k4
 
 ---
 
-Each configuration processes both **💿 [Redump](http://redump.org)** (disc-based) and **🎮 [No-Intro](https://www.no-intro.org)** (cartridge-based) DAT files with their respective filter settings.
+Each configuration processes both **💿 [Redump](https://redump.info)** (disc-based) and **🎮 [No-Intro](https://www.no-intro.org)** (cartridge-based) DAT files with their respective filter settings.
 
 ---
 
@@ -68,7 +68,7 @@ All DAT files are updated daily, so you can always get the latest filtered colle
 - **[iamyethere](https://www.reddit.com/user/iamyethere/)** for the **[PropeR 1G1R Collection](https://github.com/proper1g1r/proper1g1r-collection)** — PropeR configuration rules  
 - **[heartolazor](https://www.reddit.com/user/heartolazor/)** for the **[Hearto 1G1R Collection](https://www.reddit.com/r/Roms/comments/1k45s56/heartos_1g1r_nointroredump_collection_ds_ps1/)** — Hearto configuration rules  
 - **[unexpectedpanda](https://github.com/unexpectedpanda)** for **[Retool](https://github.com/unexpectedpanda/retool)** — The powerful 1G1R tool that makes this all possible  
-- **[Redump](http://redump.org)** — For providing disc-based DAT files  
+- **[Redump](https://redump.info)** — For providing disc-based DAT files  
 - **[No-Intro](https://www.no-intro.org)** — For providing cartridge-based DAT files
 
 ---

--- a/automate.py
+++ b/automate.py
@@ -3,7 +3,7 @@
 Automated DAT download and Retool processing script.
 
 This script:
-1. Downloads Redump .dat files from redump.org to daily-virgin-dat/redump/ directory
+1. Downloads Redump .dat files from redump.info to daily-virgin-dat/redump/ directory
 2. Downloads No-Intro .dat files from datomatic.no-intro.org to daily-virgin-dat/no-intro/ directory
 3. Downloads/sets up the latest Retool
 4. Processes all .dat files from daily-virgin-dat/redump/ and daily-virgin-dat/no-intro/ directories through Retool
@@ -48,7 +48,7 @@ HTTP_HEADERS = {
 }
 
 # Collection URLs
-REDUMP_URL = "http://redump.org"
+REDUMP_URL = "https://redump.info"
 NO_INTRO_URL = "https://datomatic.no-intro.org"
 
 
@@ -372,7 +372,7 @@ def update_retool_clone_lists(retool_dir: Path) -> None:
 
 def find_all_redump_dats():
     """Find all available Redump DAT files from the downloads page."""
-    print(f"  🌐 Connecting to Redump.org...")
+    print(f"  🌐 Connecting to Redump.info...")
     downloads_url = f"{REDUMP_URL}/downloads/"
     print(f"     URL: {downloads_url}")
     


### PR DESCRIPTION
The Redump project has officially moved from redump.org to redump.info (see https://forum.redump.info/viewtopic.php?p=117559#p117559)

## Changes
- Updated all instances of `redump.org` -> `redump.info`
- Updated new redump urls to support `https`